### PR TITLE
Minor formatting update to kitty themes, moderate update to colors for Light mode

### DIFF
--- a/extras/kitty_aquarium_dark.conf
+++ b/extras/kitty_aquarium_dark.conf
@@ -12,36 +12,36 @@ selection_background  #E5E9F0
 url_color             #cddbf9 
 
 # black
-color0      #3b3b4d
-color8      #1b1b23
+color0                #3b3b4d
+color8                #1b1b23
 
 # red
-color1      #ebb9b9
-color9      #d95e59
+color1                #ebb9b9
+color9                #d95e59
 
 # green
-color2      #caf6bb
-color10     #8fc587
+color2                #caf6bb
+color10               #8fc587
 
 # yellow
-color3      #E6DFB8
-color11     #ffcf85
+color3                #E6DFB8
+color11               #ffcf85
 
 # blue
-color4      #cddbf9
-color12     #4a83c3
+color4                #cddbf9
+color12               #4a83c3
 
 # magenta
-color5      #f6bbe7
-color13     #bf83b5
+color5                #f6bbe7
+color13               #bf83b5
 
 # cyan
-color6      #b8dceb
-color14     #4eb3cd
+color6                 #b8dceb
+color14                #4eb3cd
 
 # white
-color7      #c8cedc
-color15     #abb2c2
+color7                 #c8cedc
+color15                #abb2c2
 
 # Cursor
-cursor      #b8dceb
+cursor                 #b8dceb

--- a/extras/kitty_aquarium_light.conf
+++ b/extras/kitty_aquarium_light.conf
@@ -11,34 +11,34 @@ selection_foreground  #9CA6B9
 selection_background  #3D4059 
 url_color             #D66652 
 
-# black
-color0   #313449
-color8   #414560
+# white
+color0                #D5D4E0
+color8                #CCCBD9
 
 # red
-color1   #D04B4B
-color9   #c82828 
+color1                 #D04B4B
+color9                 #c82828 
 
 # green
-color2   #7EA070
-color10  #709760 
+color2                 #7EA070
+color10                #709760 
 
 # yellow
-color3   #EFB165 
-color11  #DDA866 
+color3                 #EFB165 
+color11                #DDA866 
 
 # blue
-color4   #547DB6 
-color12  #4170ae 
+color4                 #547DB6
+color12                #4170ae
 
 # magenta
-color5   #9F78B8 
-color13  #8958a7 
+color5                 #9F78B8
+color13                #8958a7
 
 # cyan
-color6   #829FB0
-color14  #728A9A 
+color6                 #829FB0
+color14                #728A9A
 
-# white
-color7   #D5D4E0 
-color15  #CCCBD9 
+# black
+color7                 #313449
+color15                #414560


### PR DESCRIPTION
I made a minor update to the formatting for the kitty themes so that they'd be a touch cleaner and more readable. I also switched the places of white and black for the light mode theme, because this fixes a bit of a weird thing where some programs (eg neomutt, cmus) would be using black in conspicuous places. This makes everything look more consistent. 